### PR TITLE
Partial Capture Beschreibung

### DIFF
--- a/texts/ChapterTransaction.md
+++ b/texts/ChapterTransaction.md
@@ -1758,7 +1758,11 @@ POST /Payment/v1/Transaction/Capture
 </td>
 <td class="col-sm-8">
 	
-	<div style="padding-bottom: 10px">Optional partial capture options.</div>
+	<div style="padding-bottom: 10px">Optional partial capture options.
+	>
+	>    <i class="glyphicon glyphicon-hand-right"></i> **Caution**: Partial-Captures are only available with PayPal!
+	>
+	</div>
 	<i class="small text-muted">
 			</i>
 </td>


### PR DESCRIPTION
Hinweis hinzugefügt, dass Partial-Captures ausschließlich mit PayPal machbar sind!
Zunehmend Kunden versuchen es bei Kreditkarten!