### PR TITLE
Saferpay Testcard aus Doku entfernen

### DIFF
--- a/texts/ChapterPaymentPage.md
+++ b/texts/ChapterPaymentPage.md
@@ -111,7 +111,7 @@ Numeric[8..8]<br />
 	
 	<div style="padding-bottom: 10px">Used to restrict the means of payment which are available to the payer for this transaction. If only one payment method id is set, the payment selection step will be skipped.</div>
 	<i class="small text-muted">
-Possible values: AMEX, BANCONTACT, BONUS, DINERS, DIRECTDEBIT, EPRZELEWY, EPS, GIROPAY, IDEAL, INVOICE, JCB, MAESTRO, MASTERCARD, MYONE, PAYPAL, PAYDIREKT, POSTCARD, POSTFINANCE, SAFERPAYTEST, SOFORT, VISA, VPAY.<br />
+Possible values: AMEX, BANCONTACT, BONUS, DINERS, DIRECTDEBIT, EPRZELEWY, EPS, GIROPAY, IDEAL, INVOICE, JCB, MAESTRO, MASTERCARD, MYONE, PAYPAL, PAYDIREKT, POSTCARD, POSTFINANCE, SOFORT, VISA, VPAY.<br />
 					<span>Example: [&quot;VISA&quot;, &quot;MASTERCARD&quot;]</span>
 	</i>
 </td>
@@ -626,13 +626,13 @@ Id[1..50]<br />
       "Value": "100",
       "CurrencyCode": "CHF"
     },
-    "AcquirerName": "Saferpay Test Card",
+    "AcquirerName": "VISA Saferpay Test",
     "AcquirerReference": "000000"
   },
   "PaymentMeans": {
     "Brand": {
-      "PaymentMethod": "SAFERPAYTEST",
-      "Name": "Saferpay Test Card"
+      "PaymentMethod": "VISA",
+      "Name": "VISA"
     },
     "DisplayText": "9123 45xx xxxx 1234",
     "Card": {


### PR DESCRIPTION
Wir haben, zusammen mit dem Engineering (Gert), beschlossen den Provider 90 zu entfernen, da die Simulatoren einfach besser sind.
Dazu gehört auch den Brand "SAFERPAYTEST" zu entfernen!

HINWEIS: Bitte daran denken, dass dies auch bei der Neuerstellung einer neuen Spec-Version übernommen werden muss!