### PR TITLE
Saferpay Testcard entfernen

### DIFF
--- a/texts/ChapterAliasStore.md
+++ b/texts/ChapterAliasStore.md
@@ -461,8 +461,8 @@ Id[1..50]<br />
   },
   "PaymentMeans": {
     "Brand": {
-      "PaymentMethod": "SAFERPAYTEST",
-      "Name": "Saferpay Test Card"
+      "PaymentMethod": "VISA",
+      "Name": "VISA Saferpay Test"
     },
     "DisplayText": "9123 45xx xxxx 1234",
     "Card": {
@@ -705,8 +705,8 @@ POST /Payment/v1/Alias/InsertDirect
   },
   "PaymentMeans": {
     "Brand": {
-      "PaymentMethod": "SAFERPAYTEST",
-      "Name": "Saferpay Test Card"
+      "PaymentMethod": "VISA",
+      "Name": "VISA Saferpay Test"
     },
     "DisplayText": "9123 45xx xxxx 1234",
     "Card": {


### PR DESCRIPTION
Wir haben, zusammen mit dem Engineering (Gert), beschlossen den Provider 90 zu entfernen, da die Simulatoren einfach besser sind.
Dazu gehört auch den Brand "SAFERPAYTEST" zu entfernen!

HINWEIS: Bitte daran denken, dass dies auch bei der Neuerstellung einer neuen Spec-Version übernommen werden muss!