### PR TITLE
3DS XID - Update xid description and example

### DIFF
--- a/texts/ContainerDictionary.md
+++ b/texts/ContainerDictionary.md
@@ -3051,9 +3051,9 @@ Possible values: DEFAULT, SIX, NONE.<br />
 	</span>
 </td>
 <td class="col-sm-8">
-	<div style="padding-bottom: 10px">BASE64 encoded value, given by the MPI. References the 3D Secure process.</div>
+	<div style="padding-bottom: 10px">Transaction Id, given by the MPI. References the 3D Secure process.</div>
 	<i class="small text-muted">
-					<span>Example: ARkvCgk5Y1t/BDFFXkUPGX9DUgs=</span>
+					<span>ARkvCgk5Y1t/BDFFXkUPGX9DUgs= for 3D Secure version 1 / 1ef5b3db-3b97-47df-8272-320d0bd18ab5 for 3D Secure version 2</span>
 	</i>
 </td>
 							</tr>

--- a/texts/ContainerDictionary.md
+++ b/texts/ContainerDictionary.md
@@ -3053,7 +3053,7 @@ Possible values: DEFAULT, SIX, NONE.<br />
 <td class="col-sm-8">
 	<div style="padding-bottom: 10px">Transaction Id, given by the MPI. References the 3D Secure process.</div>
 	<i class="small text-muted">
-					<span>ARkvCgk5Y1t/BDFFXkUPGX9DUgs= for 3D Secure version 1 / 1ef5b3db-3b97-47df-8272-320d0bd18ab5 for 3D Secure version 2</span>
+					<span>Example: ARkvCgk5Y1t/BDFFXkUPGX9DUgs= for 3D Secure version 1 / 1ef5b3db-3b97-47df-8272-320d0bd18ab5 for 3D Secure version 2</span>
 	</i>
 </td>
 							</tr>


### PR DESCRIPTION
3DS XID - Update xid description and example so the merchant don't rely on it to be base64. For 3dsv2 it will be a guid