### PR TITLE
Provide JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This project provides the source for [JSON API documentation](https://saferpay.github.io/jsonapi) and describes how to integrate with the newest Saferpay API.
 
+To get out JSON schema [click here](https://saferpay.github.io/jsonschema)
+
 To learn more about Saferpay please check www.saferpay.com.
 
 ### Versions


### PR DESCRIPTION
Please consider providing a JSON schema https://restfulapi.net/json-schema/
then one can convert it to an OpenAPI schema (was Swagger) https://www.npmjs.com/package/@openapi-contrib/json-schema-to-openapi-schema
then generate a **JavaScript/Nodejs SDK and in 20 other languages** https://github.com/OpenAPITools/openapi-generator

Thank you for considering!
@immiz